### PR TITLE
Replace EventBus type with Injection Module event bus strategy

### DIFF
--- a/github-users-web-client/pom.xml
+++ b/github-users-web-client/pom.xml
@@ -113,6 +113,12 @@
           <compilerArgs>-generateJsInteropExports,-optimize,9,-XnoclassMetadata</compilerArgs>
         </configuration>
       </plugin>
+      <plugin>
+        <!-- just here to make IntelliJ happy -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>gwt-maven-plugin</artifactId>
+        <version>${gwt.version}</version>
+      </plugin>
     </plugins>
   </build>
 

--- a/github-users-web-client/src/main/java/com/xemantic/ankh/Elements.java
+++ b/github-users-web-client/src/main/java/com/xemantic/ankh/Elements.java
@@ -23,7 +23,7 @@
 package com.xemantic.ankh;
 
 import com.intendia.rxgwt.elemental2.RxElemental2;
-import com.xemantic.githubusers.logic.eventbus.Trigger;
+import com.xemantic.githubusers.logic.event.Trigger;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLButtonElement;
 import elemental2.dom.HTMLElement;

--- a/github-users-web-client/src/main/java/com/xemantic/githubusers/web/GitHubUsersModule.java
+++ b/github-users-web-client/src/main/java/com/xemantic/githubusers/web/GitHubUsersModule.java
@@ -26,8 +26,9 @@ import com.intendia.gwt.autorest.client.RequestResourceBuilder;
 import com.intendia.gwt.autorest.client.ResourceVisitor;
 import com.xemantic.githubusers.logic.driver.UrlOpener;
 import com.xemantic.githubusers.logic.error.ErrorAnalyzer;
-import com.xemantic.githubusers.logic.eventbus.DefaultEventBus;
-import com.xemantic.githubusers.logic.eventbus.EventBus;
+import com.xemantic.githubusers.logic.event.SnackbarMessageEvent;
+import com.xemantic.githubusers.logic.event.UserQueryEvent;
+import com.xemantic.githubusers.logic.event.UserSelectedEvent;
 import com.xemantic.githubusers.logic.service.UserService;
 import com.xemantic.githubusers.logic.view.*;
 import com.xemantic.githubusers.web.driver.WebUrlOpener;
@@ -38,8 +39,12 @@ import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 
+import java.util.function.Consumer;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import rx.Observable;
+import rx.Observer;
+import rx.subjects.PublishSubject;
 
 /**
  * Dagger module defining component binding for the whole app.
@@ -71,11 +76,20 @@ public abstract class GitHubUsersModule {
     return "https://github.com/xemantic/github-users-web";
   }
 
-  @Provides
-  @Singleton
-  static EventBus getEventBus() {
-    return new DefaultEventBus();
-  }
+  // Snackbar message event bus
+  @Provides @Singleton static PublishSubject<SnackbarMessageEvent> snackbarMessageBus() { return PublishSubject.create(); }
+  @Provides static Consumer<SnackbarMessageEvent> snackbarMessageConsumer(PublishSubject<SnackbarMessageEvent> bus) { return bus::onNext; }
+  @Binds abstract Observable<SnackbarMessageEvent> snackbarMessageObservable(PublishSubject<SnackbarMessageEvent> bus);
+
+  // User query event bus
+  @Provides @Singleton static PublishSubject<UserQueryEvent> userQueryBus() { return PublishSubject.create(); }
+  @Provides static Consumer<UserQueryEvent> userQueryConsumer(PublishSubject<UserQueryEvent> bus) { return bus::onNext; }
+  @Binds abstract Observable<UserQueryEvent> userQueryObservable(PublishSubject<UserQueryEvent> bus);
+
+  // User selected event bus
+  @Provides @Singleton static PublishSubject<UserSelectedEvent> userSelectedBus() { return PublishSubject.create(); }
+  @Provides static Consumer<UserSelectedEvent> userSelectedConsumer(PublishSubject<UserSelectedEvent> bus) { return bus::onNext; }
+  @Binds abstract Observable<UserSelectedEvent> userSelectedObservable(PublishSubject<UserSelectedEvent> bus);
 
   @Binds
   abstract ErrorAnalyzer getErrorAnalyzer(DefaultErrorAnalyzer analyzer);

--- a/github-users-web-client/src/main/java/com/xemantic/githubusers/web/error/ExceptionHandler.java
+++ b/github-users-web-client/src/main/java/com/xemantic/githubusers/web/error/ExceptionHandler.java
@@ -24,10 +24,11 @@ package com.xemantic.githubusers.web.error;
 
 import com.google.gwt.core.client.GWT;
 import com.xemantic.githubusers.logic.event.SnackbarMessageEvent;
-import com.xemantic.githubusers.logic.eventbus.EventBus;
 
+import java.util.function.Consumer;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import rx.Observer;
 
 /**
  * Handler of uncaught exceptions in this app. It will log the error using
@@ -39,11 +40,11 @@ import javax.inject.Singleton;
 @Singleton
 public class ExceptionHandler implements GWT.UncaughtExceptionHandler {
 
-  private final EventBus eventBus;
+  private final Consumer<SnackbarMessageEvent> snackbarMessageConsumer;
 
   @Inject
-  public ExceptionHandler(EventBus eventBus) {
-    this.eventBus = eventBus;
+  public ExceptionHandler(Consumer<SnackbarMessageEvent> snackbarMessageConsumer) {
+    this.snackbarMessageConsumer = snackbarMessageConsumer;
   }
 
   /** {@inheritDoc} */
@@ -54,7 +55,7 @@ public class ExceptionHandler implements GWT.UncaughtExceptionHandler {
 
   // use this method if you need to notify user about certain errors.
   private void postSnackbarMessage(String message) {
-    eventBus.post(new SnackbarMessageEvent(message));
+    snackbarMessageConsumer.accept(new SnackbarMessageEvent(message));
   }
 
 }

--- a/github-users-web-client/src/main/java/com/xemantic/githubusers/web/navigation/UserSelectionNavigator.java
+++ b/github-users-web-client/src/main/java/com/xemantic/githubusers/web/navigation/UserSelectionNavigator.java
@@ -24,10 +24,10 @@ package com.xemantic.githubusers.web.navigation;
 
 import com.xemantic.githubusers.logic.driver.UrlOpener;
 import com.xemantic.githubusers.logic.event.UserSelectedEvent;
-import com.xemantic.githubusers.logic.eventbus.EventBus;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import rx.Observable;
 
 /**
  * Will open user profile page if the user is selected.
@@ -37,22 +37,21 @@ import javax.inject.Singleton;
 @Singleton
 public class UserSelectionNavigator {
 
-  private final EventBus eventBus;
+  private final Observable<UserSelectedEvent> userSelected$;
 
   private final UrlOpener urlOpener;
 
   @Inject
   public UserSelectionNavigator(
-      EventBus eventBus,
+      Observable<UserSelectedEvent> userSelected$,
       UrlOpener urlOpener) {
 
-    this.eventBus = eventBus;
+    this.userSelected$ = userSelected$;
     this.urlOpener = urlOpener;
   }
 
   public void start() {
-    eventBus.observe(UserSelectedEvent.class)
-        .subscribe(event -> urlOpener.openUrl(event.getUser().getHtmlUrl()));
+    userSelected$.subscribe(event -> urlOpener.openUrl(event.getUser().getHtmlUrl()));
   }
 
 }

--- a/github-users-web-client/src/main/java/com/xemantic/githubusers/web/service/GitHubApiErrorHandler.java
+++ b/github-users-web-client/src/main/java/com/xemantic/githubusers/web/service/GitHubApiErrorHandler.java
@@ -24,10 +24,11 @@ package com.xemantic.githubusers.web.service;
 
 import com.intendia.gwt.autorest.client.RequestResourceBuilder.FailedStatusCodeException;
 import com.xemantic.githubusers.logic.event.SnackbarMessageEvent;
-import com.xemantic.githubusers.logic.eventbus.EventBus;
 
+import java.util.function.Consumer;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import rx.Observer;
 
 /**
  * Error handler for GitHub APIs.
@@ -37,11 +38,11 @@ import javax.inject.Singleton;
 @Singleton
 public class GitHubApiErrorHandler {
 
-  private final EventBus eventBus;
+  private final Consumer<SnackbarMessageEvent> snackbarMessageConsumer;
 
   @Inject
-  public GitHubApiErrorHandler(EventBus eventBus) {
-    this.eventBus = eventBus;
+  public GitHubApiErrorHandler(Consumer<SnackbarMessageEvent> snackbarMessageConsumer) {
+    this.snackbarMessageConsumer = snackbarMessageConsumer;
   }
 
   public void handleError(Throwable throwable) {
@@ -56,7 +57,7 @@ public class GitHubApiErrorHandler {
   private boolean handleStatusCode(FailedStatusCodeException e) {
     String message = getMessage(e.getStatusCode());
     if (message != null) {
-      eventBus.post(new SnackbarMessageEvent(message));
+      snackbarMessageConsumer.accept(new SnackbarMessageEvent(message));
       return true;
     }
     return false;

--- a/github-users-web-client/src/main/java/com/xemantic/githubusers/web/view/WebDrawerView.java
+++ b/github-users-web-client/src/main/java/com/xemantic/githubusers/web/view/WebDrawerView.java
@@ -24,7 +24,7 @@ package com.xemantic.githubusers.web.view;
 
 import com.xemantic.ankh.Elements;
 import com.xemantic.ankh.IncrementalDom;
-import com.xemantic.githubusers.logic.eventbus.Trigger;
+import com.xemantic.githubusers.logic.event.Trigger;
 import com.xemantic.githubusers.logic.view.DrawerView;
 import elemental2.dom.Element;
 import mdc.drawer.MDCTemporaryDrawer;

--- a/github-users-web-client/src/main/java/com/xemantic/githubusers/web/view/WebUserListView.java
+++ b/github-users-web-client/src/main/java/com/xemantic/githubusers/web/view/WebUserListView.java
@@ -24,7 +24,7 @@ package com.xemantic.githubusers.web.view;
 
 import com.xemantic.ankh.Elements;
 import com.xemantic.ankh.IncrementalDom;
-import com.xemantic.githubusers.logic.eventbus.Trigger;
+import com.xemantic.githubusers.logic.event.Trigger;
 import com.xemantic.githubusers.logic.view.UserListView;
 import com.xemantic.githubusers.logic.view.UserView;
 import elemental2.dom.Element;

--- a/github-users-web-client/src/main/java/com/xemantic/githubusers/web/view/WebUserView.java
+++ b/github-users-web-client/src/main/java/com/xemantic/githubusers/web/view/WebUserView.java
@@ -22,7 +22,7 @@
 package com.xemantic.githubusers.web.view;
 
 import com.xemantic.ankh.Elements;
-import com.xemantic.githubusers.logic.eventbus.Trigger;
+import com.xemantic.githubusers.logic.event.Trigger;
 import com.xemantic.githubusers.logic.model.User;
 import com.xemantic.githubusers.logic.view.UserView;
 import com.xemantic.ankh.IncrementalDom;


### PR DESCRIPTION
The event bus maps event types so a developer can publish or observe
event of a specific type. EventBus was a quite useful utility, but now
with type injections, module definitions and async libraries like RxJava
you can use the concept of event bus without the explicit event bus. Now
the event bus is implicit in the whole app. If you wan to emmit events,
you inject Observer<EventType> and if you want to listen to events you
inject Observable<EventType>. This IMO is even better than traditional
event bus bc it force you to describe which kind of event you are
actually using.